### PR TITLE
Fix call to incorrect method in IGetDeclaringClass

### DIFF
--- a/Test_Engine/Query/GetDelaringClass.cs
+++ b/Test_Engine/Query/GetDelaringClass.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Test
     {
         public static ClassDeclarationSyntax IGetDeclaringClass(this SyntaxNode node)
         {
-            return GetClass(node as dynamic);
+            return GetDeclaringClass(node as dynamic);
         }
 
         public static ClassDeclarationSyntax GetDeclaringClass(this SyntaxNode node)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #46 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->