### PR TITLE
Update installer building commands

### DIFF
--- a/BuildInstaller.ps1
+++ b/BuildInstaller.ps1
@@ -31,14 +31,14 @@ git clone -q --branch=master https://github.com/BHoM/BHoM_Datasets.git  $ENV:BUI
 write-Output ("**** ITERATE OVER ALL DEPENDENCIES ****")
 ForEach ($repo in $dependencies) 
 {
-  & "$ENV:BUILD_SOURCESDIRECTORY\Test_Toolkit\CloneAndBuildRepo.ps1" -repo $repo
+  & "$ENV:BUILD_SOURCESDIRECTORY\Test_Toolkit\CloneAndBuildRepoWithMerge.ps1" -repo $repo
 }
 
 
 # **** Iterate over all Toolkits to Include ****
 write-Output ("**** ITERATE OVER ALL TOOLKITS TO INCLUDE ****")
 ForEach ($repo in $includes) {
-  & "$ENV:BUILD_SOURCESDIRECTORY\Test_Toolkit\CloneAndBuildRepo.ps1" -repo $repo
+  & "$ENV:BUILD_SOURCESDIRECTORY\Test_Toolkit\CloneAndBuildRepoWithMerge.ps1" -repo $repo
 }
 
 
@@ -62,6 +62,6 @@ ForEach ($altconfig in $altconfigs)
 write-Output ("**** ITERATE OVER ALL USER INTERFACES ****")
 ForEach ($repo in $uis) 
 {
-  & "$ENV:BUILD_SOURCESDIRECTORY\Test_Toolkit\CloneAndBuildRepo.ps1" -repo $repo
+  & "$ENV:BUILD_SOURCESDIRECTORY\Test_Toolkit\CloneAndBuildRepoWithMerge.ps1" -repo $repo
 }
 

--- a/CloneAndBuildRepoWithMerge.ps1
+++ b/CloneAndBuildRepoWithMerge.ps1
@@ -1,0 +1,67 @@
+Param([string]$repo)
+
+# **** Constants ****
+$msbuildPath = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
+
+$parts = $repo.split("/")
+$org = $parts[0]
+$repo = $parts[1]
+
+$slnPath = "$ENV:BUILD_SOURCESDIRECTORY\$repo\$repo.sln"
+
+If(test-path "$ENV:BUILD_SOURCESDIRECTORY\$repo")
+{
+	Write-Output ("Deleting folder if it exists before cloning...")
+	Remove-Item -LiteralPath "$ENV:BUILD_SOURCESDIRECTORY\$repo" -Force -Recurse
+}
+
+# **** Cloning Repo ****
+Write-Output ("Cloning " + $repo + " to " + $ENV:BUILD_SOURCESDIRECTORY + "\" + $repo)
+git clone -q --branch=master https://github.com/$org/$repo.git $ENV:BUILD_SOURCESDIRECTORY\$repo
+
+If(-not $?)
+{
+	Write-Error  "##vso[task.logissue type=error;]Failed '$repo'"
+	return
+}
+
+# Switch branch in case there are dependant PRs happening...
+$branch = $ENV:SYSTEM_PULLREQUEST_SOURCEBRANCH
+If ($branch -ne "master")
+{
+	$cwd = Get-Location
+	Set-Location $ENV:BUILD_SOURCESDIRECTORY\$repo
+
+	If((git rev-parse --verify --quiet ("origin/"+$branch)).length -gt 0)
+	{
+		Write-Output("Changing branch in repo " + $repo + " to " + $branch)
+		git checkout --quiet $branch
+		Write-Output("Merging master branch into " + $branch)
+		git merge master
+	}
+	Else
+	{
+		Write-Output("Staying on master branch for " + $repo)
+	}
+
+	Set-Location $cwd
+}
+Else
+{
+	Write-Output("Staying on master branch for " + $repo)
+}
+
+
+# **** Restore NuGet ****
+Write-Output ("Restoring NuGet packages for " + $repo)
+& NuGet.exe restore $slnPath
+
+# **** Building .sln ****
+write-Output ("Building " + $repo + ".sln")
+& $msbuildPath -nologo $slnPath /verbosity:minimal
+
+If(-not $?)
+{
+	Write-Error  "##vso[task.logissue type=error;]Failed '$repo'"
+	return
+}

--- a/CloneAndBuildRepoWithMerge.ps1
+++ b/CloneAndBuildRepoWithMerge.ps1
@@ -34,10 +34,8 @@ If ($branch -ne "master")
 
 	If((git rev-parse --verify --quiet ("origin/"+$branch)).length -gt 0)
 	{
-		Write-Output("Changing branch in repo " + $repo + " to " + $branch)
-		git checkout --quiet $branch
-		Write-Output("Merging master branch into " + $branch)
-		git merge master
+		Write-Output("Merging branch " + $branch " in repo " + $repo + " to master")
+		git merge $branch
 	}
 	Else
 	{


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #60 


 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
Installer building of repos is now done by merging `master` into any dependant branches. This makes sense to me because ultimately, the installer won't build with the PR code until it is merged into `master` so that is what we want to check with, rather than in isolation as the other checks do.