### PR TITLE
Don't check output attribute on methods with void return type

### DIFF
--- a/CodeComplianceTest_Engine/Query/Checks/HasOutputAttribute.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasOutputAttribute.cs
@@ -22,6 +22,7 @@
 
 using BH.oM.Test;
 using BH.oM.Test.Attributes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
@@ -40,7 +41,10 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [IsPublic()]
         public static Span HasOutputAttribute(MethodDeclarationSyntax node)
         {
-            return node.HasAttribute("Output") || node.HasAttribute("MultiOutput")  ? null : node.Identifier.Span.ToBHoM();
+           
+           
+            return ((PredefinedTypeSyntax)node.ReturnType).Keyword.Kind() == SyntaxKind.VoidKeyword
+                || node.HasAttribute("Output") || node.HasAttribute("MultiOutput")  ? null : node.Identifier.Span.ToBHoM();
         }
 
         [Message("Method must contain an Output or MultiOutput attribute")]


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #121 

 <!-- Add short description of what has been fixed -->
As title

 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EoPWbwmhLx1Kh5fqFizd9P4BddiDIw-AAOaEZ5oyBJjW3g?e=LHnX7X

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->