### PR TITLE
Allow path to contain return type rather than only filename

### DIFF
--- a/CodeComplianceTest_Engine/Query/Checks/CreateMethodFileNameMatchesReturnType.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/CreateMethodFileNameMatchesReturnType.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     public static partial class Query
     {
 
-        [Message("Create filename must match the create method(s) return type")]
+        [Message("Create file path must match the create method(s) return type. Either part of the path or the filename must be an exact match of the return type of the method")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Create\\.*\.cs$")]
         [IsPublic()]
         public static Span CreateMethodFileNameMatchesReturnType(MethodDeclarationSyntax node)
@@ -47,12 +47,17 @@ namespace BH.Engine.Test.CodeCompliance.Checks
 
             if (!string.IsNullOrEmpty(filePath))
             {
-                string fileName = System.IO.Path.GetFileName(filePath);
-                fileName = fileName.Remove(fileName.LastIndexOf('.'));
-                if(!Regex.Match(returnType, $"((List|IEnumerable)<)?I?{fileName}(<.*>)?>?$").Success)
+                string fileName;
+                do
                 {
-                    return node.Identifier.Span.ToBHoM();
+                    fileName = System.IO.Path.GetFileNameWithoutExtension(filePath);
+                    if (string.IsNullOrEmpty(fileName))
+                    {
+                        return node.Identifier.Span.ToBHoM();
+                    }
+                    filePath = System.IO.Path.GetDirectoryName(filePath);
                 }
+                while (!Regex.Match(returnType, $"((List|IEnumerable)<)?I?{fileName}(<.*>)?>?$").Success) ;
             }
 
             return null;

--- a/CodeComplianceTest_Engine/Query/Checks/CreateMethodFileNameMatchesReturnType.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/CreateMethodFileNameMatchesReturnType.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     public static partial class Query
     {
 
-        [Message("Create file path must match the create method(s) return type. Either part of the path or the filename must be an exact match of the return type of the method")]
+        [Message("Create file path must match the create method(s) return type. Either part of the path or the filename must be an exact match of the return type of the method.")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Create\\.*\.cs$")]
         [IsPublic()]
         public static Span CreateMethodFileNameMatchesReturnType(MethodDeclarationSyntax node)
@@ -45,9 +45,9 @@ namespace BH.Engine.Test.CodeCompliance.Checks
             if (type is QualifiedNameSyntax) type = ((QualifiedNameSyntax)type).Right;
             string returnType = type.ToString();
 
+            string fileName;
             if (!string.IsNullOrEmpty(filePath))
             {
-                string fileName;
                 do
                 {
                     fileName = System.IO.Path.GetFileNameWithoutExtension(filePath);
@@ -58,6 +58,14 @@ namespace BH.Engine.Test.CodeCompliance.Checks
                     filePath = System.IO.Path.GetDirectoryName(filePath);
                 }
                 while (!Regex.Match(returnType, $"((List|IEnumerable)<)?I?{fileName}(<.*>)?>?$").Success) ;
+            }
+
+            filePath = node.SyntaxTree.FilePath;
+            fileName = System.IO.Path.GetFileNameWithoutExtension(filePath);
+            if (!Regex.Match(returnType, $"((List|IEnumerable)<)?I?{fileName}(<.*>)?>?$").Success && 
+                !Regex.Match(node.Identifier.ToString(), $"I?{fileName}$").Success)
+            {
+                return node.Identifier.Span.ToBHoM();
             }
 
             return null;

--- a/CodeComplianceTest_Engine/Query/Checks/CreateMethodFileNameMatchesReturnType.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/CreateMethodFileNameMatchesReturnType.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     public static partial class Query
     {
 
-        [Message("Create file path must match the create method(s) return type. Either part of the path or the filename must be an exact match of the return type of the method.")]
+        [Message("Create file  must match the create method(s) return type. Either part of the path or the filename must be an exact match of the return type of the method. If the file name does not match the return type file name must match the method name.")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Create\\.*\.cs$")]
         [IsPublic()]
         public static Span CreateMethodFileNameMatchesReturnType(MethodDeclarationSyntax node)
@@ -45,7 +45,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
             if (type is QualifiedNameSyntax) type = ((QualifiedNameSyntax)type).Right;
             string returnType = type.ToString();
 
-            string fileName;
+            string fileName = "";
             if (!string.IsNullOrEmpty(filePath))
             {
                 do
@@ -57,16 +57,16 @@ namespace BH.Engine.Test.CodeCompliance.Checks
                     }
                     filePath = System.IO.Path.GetDirectoryName(filePath);
                 }
-                while (!Regex.Match(returnType, $"((List|IEnumerable)<)?I?{fileName}(<.*>)?>?$").Success) ;
-            }
+                while (!Regex.Match(returnType, $"((List|IEnumerable)<)?I?{fileName}(<.*>)?>?$").Success);
 
-            filePath = node.SyntaxTree.FilePath;
-            fileName = System.IO.Path.GetFileNameWithoutExtension(filePath);
-            if (!Regex.Match(returnType, $"((List|IEnumerable)<)?I?{fileName}(<.*>)?>?$").Success && 
-                !Regex.Match(node.Identifier.ToString(), $"I?{fileName}$").Success)
-            {
-                return node.Identifier.Span.ToBHoM();
-            }
+                filePath = node.SyntaxTree.FilePath;
+                fileName = System.IO.Path.GetFileNameWithoutExtension(filePath);
+                if (!Regex.Match(returnType, $"((List|IEnumerable)<)?I?{fileName}(<.*>)?>?$").Success &&
+                    !Regex.Match(node.Identifier.ToString(), $"I?{fileName}$").Success)
+                {
+                    return node.Identifier.Span.ToBHoM();
+                }
+            }   
 
             return null;
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #142 

As per https://github.com/BHoM/Test_Toolkit/issues/142#issuecomment-587403157 
> EITHER
> 
>  - Create method file names must match their return type (e.g. Blah.cs contains only Create methods which return Blah objects)
> 
> OR
> 
>  - The Create method filepath must contain the return type AND the method name must match the file name


 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->