### PR TITLE
Add check that Input Attributes are unique

### DIFF
--- a/CodeComplianceTest_Engine/CodeComplianceTest_Engine.csproj
+++ b/CodeComplianceTest_Engine/CodeComplianceTest_Engine.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Query\Checks\EngineClassMatchesFilePath.cs" />
     <Compile Include="Query\Checks\HasMatchingInputDescription.cs" />
     <Compile Include="Query\Checks\HasSingleClass.cs" />
+    <Compile Include="Query\Checks\InputAttributeIsUnique.cs" />
     <Compile Include="Query\Checks\InputParameterStartsLower.cs" />
     <Compile Include="Query\Checks\MethodNameStartsUpper.cs" />
     <Compile Include="Query\Checks\HasOutputAttribute.cs" />

--- a/CodeComplianceTest_Engine/Query/Checks/InputAttributeIsUnique.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/InputAttributeIsUnique.cs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Test;
+using BH.oM.Test.Attributes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.Test.CodeCompliance.Checks
+{
+    public static partial class Query
+    {
+        [Message("Input attribute is not unique")]
+        [ErrorLevel(ErrorLevel.Error)]
+        [Path(@"([a-zA-Z0-9]+)_(Engine|Adapter)\\.*\.cs$")]
+        public static Span InputAttributeIsUnique(AttributeSyntax node)
+        {
+            if (node.Name.ToString() != "Input") return null;
+
+            var method = node.Parent.Parent as BaseMethodDeclarationSyntax;
+            if (method != null && method.IsPublic() && (method.IsEngineMethod() || method.IsAdapterConstructor()))
+            {
+                string paramname = node.ArgumentList.Arguments[0].Expression.GetFirstToken().Value.ToString();
+                var firstOfName = method.InputAttributes().First(attr => attr.ArgumentList.Arguments[0].Expression.GetFirstToken().Value.ToString() == paramname);
+                if (firstOfName != node)
+                {
+                    return node.Span.ToBHoM();
+                }
+            }
+            return null;
+        }
+    }
+}
+

--- a/CodeComplianceTest_Test/AdapterTests/InputAttributeIsUnique.cs
+++ b/CodeComplianceTest_Test/AdapterTests/InputAttributeIsUnique.cs
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Test.Test
+{
+    public partial class Test_Adapter
+    {
+        [TestMethod]
+        public void InputAttributeIsUnique()
+        {
+            Test.RunTest("InputAttributeIsUnique", GetChangedObjectFiles());
+        }
+    }
+}

--- a/CodeComplianceTest_Test/CodeComplianceTest_Test.csproj
+++ b/CodeComplianceTest_Test/CodeComplianceTest_Test.csproj
@@ -123,11 +123,13 @@
     <Compile Include="AdapterTests\HasValidCopyright.cs" />
     <Compile Include="AdapterTests\GetFiles.cs" />
     <Compile Include="AdapterTests\HasSingleClass.cs" />
+    <Compile Include="AdapterTests\InputAttributeIsUnique.cs" />
     <Compile Include="AdapterTests\InputParameterStartsLower.cs" />
     <Compile Include="AdapterTests\MethodNameStartsUpper.cs" />
     <Compile Include="EngineTests\CheckProjectFile.cs" />
     <Compile Include="EngineTests\CreateMethodFileNameMatchesReturnType.cs" />
     <Compile Include="EngineTests\HasSingleClass.cs" />
+    <Compile Include="EngineTests\InputAttributeIsUnique.cs" />
     <Compile Include="EngineTests\MethodNameStartsUpper.cs" />
     <Compile Include="EngineTests\IsUniqueOutputAttribute.cs" />
     <Compile Include="EngineTests\IsUniqueDescriptionAttribute.cs" />

--- a/CodeComplianceTest_Test/EngineTests/InputAttributeIsUnique.cs
+++ b/CodeComplianceTest_Test/EngineTests/InputAttributeIsUnique.cs
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Test.Test
+{
+    public partial class Test_Engine
+    {
+        [TestMethod]
+        public void InputAttributeIsUnique()
+        {
+            Test.RunTest("InputAttributeIsUnique", GetChangedObjectFiles());
+        }
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #149 

Adds a compliance check to assert that an input attribute is the only one of a given name for a method.


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EkB_N9Q49txFpBAtxzqL_MMB8D3KQ3au1LWawcOqeEDe_w?e=yZXVX1

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->