### PR TITLE
Add HasValidOutputAttribute test

### DIFF
--- a/CodeComplianceTest_Engine/CodeComplianceTest_Engine.csproj
+++ b/CodeComplianceTest_Engine/CodeComplianceTest_Engine.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Query\Checks\CreateMethodFileNameMatchesReturnType.cs" />
     <Compile Include="Query\Checks\HasDescriptionAttribute.cs" />
     <Compile Include="Query\Checks\EngineClassMatchesFilePath.cs" />
+    <Compile Include="Query\Checks\HasValidOutputAttribute.cs" />
     <Compile Include="Query\Checks\IsInputAttributePresent.cs" />
     <Compile Include="Query\Checks\HasSingleClass.cs" />
     <Compile Include="Query\Checks\InputAttributeIsUnique.cs" />

--- a/CodeComplianceTest_Engine/Query/GetName.cs
+++ b/CodeComplianceTest_Engine/Query/GetName.cs
@@ -34,7 +34,6 @@ namespace BH.Engine.Test.CodeCompliance
 {
     public static partial class Query
     {
-        [MultiOutput(0, "Blah", "Blah")]
         public static string IGetName(this MemberDeclarationSyntax node)
         {
             return GetName(node as dynamic);

--- a/CodeComplianceTest_Engine/Query/GetName.cs
+++ b/CodeComplianceTest_Engine/Query/GetName.cs
@@ -28,11 +28,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Test.CodeCompliance
 {
     public static partial class Query
     {
+        [MultiOutput(0, "Blah", "Blah")]
         public static string IGetName(this MemberDeclarationSyntax node)
         {
             return GetName(node as dynamic);

--- a/CodeComplianceTest_Engine/Query/IsDeprecated.cs
+++ b/CodeComplianceTest_Engine/Query/IsDeprecated.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Test.CodeCompliance
     {
         public static bool IsDeprecated(this MemberDeclarationSyntax node)
         {
-            return node.HasAttribute("Deprecated");
+            return node.HasAttribute("Deprecated") || node.HasAttribute("ToBeRemoved") || node.HasAttribute("Replaced");
         }
     }
 }

--- a/CodeComplianceTest_Test/AdapterTests/HasValidOutputAttribute.cs
+++ b/CodeComplianceTest_Test/AdapterTests/HasValidOutputAttribute.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Test.Test
+{
+    public partial class Test_Adapter
+    {
+        [TestMethod]
+        public void HasValidOutputAttribute()
+        {
+            Test.RunTest("HasValidOutputAttribute", GetChangedObjectFiles(), GetProjectName());
+        }
+    }
+}

--- a/CodeComplianceTest_Test/CodeComplianceTest_Test.csproj
+++ b/CodeComplianceTest_Test/CodeComplianceTest_Test.csproj
@@ -128,6 +128,7 @@
     <Compile Include="AdapterTests\HasValidCopyright.cs" />
     <Compile Include="AdapterTests\GetFiles.cs" />
     <Compile Include="AdapterTests\HasSingleClass.cs" />
+    <Compile Include="AdapterTests\HasValidOutputAttribute.cs" />
     <Compile Include="AdapterTests\InputAttributeIsUnique.cs" />
     <Compile Include="AdapterTests\InputParameterStartsLower.cs" />
     <Compile Include="AdapterTests\MethodNameStartsUpper.cs" />
@@ -136,6 +137,7 @@
     <Compile Include="EngineTests\CreateMethodFileNameMatchesReturnType.cs" />
     <Compile Include="EngineTests\HasSingleClass.cs" />
     <Compile Include="EngineTests\HasSingleNamespace.cs" />
+    <Compile Include="EngineTests\HasValidOutputAttributecs.cs" />
     <Compile Include="EngineTests\InputAttributeIsUnique.cs" />
     <Compile Include="EngineTests\IsExtensionMethod.cs" />
     <Compile Include="EngineTests\MethodNameStartsUpper.cs" />

--- a/CodeComplianceTest_Test/EngineTests/HasValidOutputAttributecs.cs
+++ b/CodeComplianceTest_Test/EngineTests/HasValidOutputAttributecs.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Test.Test
+{
+    public partial class Test_Engine
+    {
+        [TestMethod]
+        public void HasValidOutputAttribute()
+        {
+            Test.RunTest("HasValidOutputAttribute", GetChangedObjectFiles(), GetProjectName());
+        }
+    }
+}


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #189 


 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
If a method has `MultiOutput` attribute then they also have to be using `Output<t1, tn>` return type. If a method has an `Output` attribute then it cannot have the `Output<t1, tn>` return type.

Full documentation can be found [here](https://github.com/BHoM/documentation/wiki/HasValidOutputAttribute)