### PR TITLE
Test_Engine: Prevent creation of Deprecated object when using DummyObject

### DIFF
--- a/Test_Engine/Compute/DummyObject.cs
+++ b/Test_Engine/Compute/DummyObject.cs
@@ -314,7 +314,7 @@ namespace BH.Engine.Test
             {
                 try
                 {
-                    if (!type.IsAbstract && !type.IsInterface && !type.IsEnum)
+                    if (!type.IsAbstract && !type.IsInterface && !type.IsEnum && !type.IsDeprecated())
                     {
                         foreach (Type inter in type.GetInterfaces())
                         {


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #266

See issue for details

 ### Additional comments
- To run the test shown in the issue you will need to run the latest installer and compile the `Test_Toolkit`
- I see this as a safe fix to be merge this week. Especially since the test toolkit is not part of the installer.