### PR TITLE
Adding converter between Debug Event and TestMessage

### DIFF
--- a/TestRunner/Program.cs
+++ b/TestRunner/Program.cs
@@ -30,6 +30,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Test;
+using BH.Engine.Test;
 
 namespace TestRunner
 {
@@ -61,10 +62,8 @@ namespace TestRunner
                     try
                     {
                         TestResult result = method.Invoke(null, new object[] { }) as TestResult;
-
-                        Console.WriteLine(result.Description + " --> " + result.Status.ToString());
-                        foreach (ITestInformation testInfo in result.Information.OrderBy(x => x.Message))
-                            Console.WriteLine("  - " + testInfo.Message);
+                        Console.WriteLine();
+                        Console.Write(result.FullMessage());
                     }
                     catch (Exception e)
                     {

--- a/TestRunner/TestRunner.csproj
+++ b/TestRunner/TestRunner.csproj
@@ -62,5 +62,11 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Test_Engine\Test_Engine.csproj">
+      <Project>{5FC85409-DBC5-4B0D-A2AA-1D9542F0763B}</Project>
+      <Name>Test_Engine</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Test_Engine/Convert/ToEventMessage.cs
+++ b/Test_Engine/Convert/ToEventMessage.cs
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Test.Results;
+using BH.oM.Reflection.Debugging;
+
+namespace BH.Engine.Test
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Convert a debugging event into a test event message.")]
+        [Input("debugEvent", "Debugging event to convert")]
+        [Output("message", "resulting test event message.")]
+        public static EventMessage ToEventMessage(this Event debugEvent)
+        {
+            return new EventMessage
+            {
+                Message = debugEvent.Message,
+                Status = debugEvent.Type.ToTestStatus(),
+                StackTrace = debugEvent.StackTrace,
+                UTCTime = debugEvent.UtcTime
+            };
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Test_Engine/Convert/ToTestStatus.cs
+++ b/Test_Engine/Convert/ToTestStatus.cs
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Reflection.Debugging;
+using BH.oM.Test;
+
+namespace BH.Engine.Test
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Convert a debugging event type into a test status.")]
+        [Input("eventType", "Debugging event type to convert")]
+        [Output("status", "resulting test status.")]
+        public static TestStatus ToTestStatus(this EventType eventType)
+        {
+            switch (eventType)
+            {
+                case EventType.Error:
+                    return TestStatus.Error;
+                case EventType.Warning:
+                    return TestStatus.Warning;
+                case EventType.Note:
+                    return TestStatus.Pass;
+                default:
+                    return TestStatus.Pass;
+            }
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Test_Engine/Test_Engine.csproj
+++ b/Test_Engine/Test_Engine.csproj
@@ -67,6 +67,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Convert\ToEventMessage.cs" />
+    <Compile Include="Convert\ToTestStatus.cs" />
     <Compile Include="Create\PassResult.cs" />
     <Compile Include="Create\FailResult.cs" />
     <Compile Include="Compute\DummyObject.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
https://github.com/BHoM/BHoM/pull/1182


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #329 

Nothing too fancy, I have just added a centralised converter between debug events and `EventMessage` to avoid having to rewrite that everywhere. 


 ### Additional comments
This can (and probably should) actually be merged at the same time as https://github.com/BHoM/BHoM/pull/1182.
I don't see those specific methods needing further changes so I didn't set this PR as draft. If there are further changes needed for the `Verify.sln` I'd rather do them in a separate PR.