### PR TITLE
Update warnings and errors

### DIFF
--- a/CodeComplianceTest_Engine/Query/Checks/EngineClassMatchesFilePath.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/EngineClassMatchesFilePath.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -38,6 +39,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([A-Za-z0-9]+)_Engine\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span EngineClassMatchesFilePath(this ClassDeclarationSyntax node)
         {
             if (node == null)

--- a/CodeComplianceTest_Engine/Query/Checks/HasDescriptionAttribute.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasDescriptionAttribute.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     public static partial class Query
     {
         [Message("Engine Method must contain a Description attribute", "HasDescriptionAttribute")]
-        [ErrorLevel(TestStatus.Warning)]
+        [ErrorLevel(TestStatus.Error)]
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
         [IsPublic()]

--- a/CodeComplianceTest_Engine/Query/Checks/HasPublicGet.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasPublicGet.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -40,6 +41,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]
         [IsPublic()]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span HasPublicGet(this PropertyDeclarationSyntax node)
         {
             if (node == null)

--- a/CodeComplianceTest_Engine/Query/Checks/HasSingleClass.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasSingleClass.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -37,6 +38,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)(_?oM|_(Engine|UI|Adapter))\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span HasSingleClass(this BaseTypeDeclarationSyntax node)
         {
             if (node == null || !node.SyntaxTree.HasCompilationUnitRoot)

--- a/CodeComplianceTest_Engine/Query/Checks/HasSingleNamespace.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasSingleNamespace.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -37,6 +38,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)(_?oM|_(Engine|UI|Adapter))\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span HasSingleNamespace(this NamespaceDeclarationSyntax node)
         {
             if (node == null || !node.SyntaxTree.HasCompilationUnitRoot)

--- a/CodeComplianceTest_Engine/Query/Checks/HasValidCopyright.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasValidCopyright.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -35,6 +36,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     {
         [Message("Copyright message is invalid", "HasValidCopyright")]
         [ComplianceType("copyright")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span HasValidCopyright(this CompilationUnitSyntax node)
         {
             if (node == null)

--- a/CodeComplianceTest_Engine/Query/Checks/IsExtensionMethod.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsExtensionMethod.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -42,6 +43,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
         [IsPublic()]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span IsExtensionMethod(this MethodDeclarationSyntax node)
         {
             if (node == null)

--- a/CodeComplianceTest_Engine/Query/Checks/IsPublicClass.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsPublicClass.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -39,6 +40,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
         [IsPublic(false)]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         [Output("A span that represents where this error resides or null if there is no error")]
         public static Span IsPublicClass(this ClassDeclarationSyntax node)
         {

--- a/CodeComplianceTest_Engine/Query/Checks/IsPublicProperty.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsPublicProperty.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -40,6 +41,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]
         [IsPublic(false)]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span IsPublicProperty(this PropertyDeclarationSyntax node)
         {
             if (node == null)

--- a/CodeComplianceTest_Engine/Query/Checks/IsStaticClass.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsStaticClass.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -38,6 +39,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span IsStaticClass(this ClassDeclarationSyntax node)
         {
             return node == null || node.IsStatic() ? null : node.Modifiers.Span.ToSpan();

--- a/CodeComplianceTest_Engine/Query/Checks/IsValidConvertMethodName.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsValidConvertMethodName.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -38,6 +39,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Adapter\\Convert\\.*\.cs$")]
         [IsPublic()]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span IsValidConvertMethodName(this MethodDeclarationSyntax node)
         {
             if (node == null)

--- a/CodeComplianceTest_Engine/Query/Checks/IsValidCreateMethod.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsValidCreateMethod.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -39,6 +40,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\Create\\.*\.cs$")]
         [IsPublic()]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span IsValidCreateMethod(this MethodDeclarationSyntax node)
         {
             if (node == null)

--- a/CodeComplianceTest_Engine/Query/Checks/IsValidCreateMethodName.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsValidCreateMethodName.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -38,6 +39,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\Create\\.*\.cs$")]
         [IsPublic()]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span IsValidCreateMethodName(this MethodDeclarationSyntax node)
         {
             if (node == null)

--- a/CodeComplianceTest_Engine/Query/Checks/IsValidEngineClassName.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsValidEngineClassName.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -37,6 +38,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span IsValidEngineClassName(this ClassDeclarationSyntax node)
         {
             List<string> validEngineClassNames = new List<string>() { "Create", "Convert", "Query", "Modify", "Compute" };

--- a/CodeComplianceTest_Engine/Query/Checks/IsVirtualProperty.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsVirtualProperty.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -40,6 +41,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]
         [IsPublic()]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span IsVirtualProperty(this PropertyDeclarationSyntax node)
         {
             if (node == null)

--- a/CodeComplianceTest_Engine/Query/Checks/MethodNameContainsFileName.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/MethodNameContainsFileName.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -40,6 +41,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
         [IsPublic()]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span MethodNameContainsFileName(this MethodDeclarationSyntax node)
         {
             if (node == null)

--- a/CodeComplianceTest_Engine/Query/Checks/ModifyReturnsDifferentType.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/ModifyReturnsDifferentType.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -38,6 +39,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\Modify\\.*\.cs$")]
         [IsPublic()]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Warning)]
         public static Span ModifyReturnsDifferentType(this MethodDeclarationSyntax node)
         {
             if (node == null)

--- a/CodeComplianceTest_Engine/Query/Checks/PropertyAccessorsHaveNoBody.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/PropertyAccessorsHaveNoBody.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Test;
 
 namespace BH.Engine.Test.CodeCompliance.Checks
 {
@@ -40,6 +41,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]
         [IsPublic()]
         [ComplianceType("code")]
+        [ErrorLevel(TestStatus.Error)]
         public static Span PropertyAccessorsHaveNoBody(this PropertyDeclarationSyntax node)
         {
             if (node == null || node.AccessorList == null)


### PR DESCRIPTION
Full review of what is a warning vs and error for the 4.3 milestone was conducted and updates have been made accordingly.

A lot of classes were `[ErrorLevel(TestStatus.Error)]` by default (i.e. no attribute is == to an error), so I have added some simply for transparency for the next review to avoid the ambiguity. Those files changed which just have that added are therefore no change to the result for compliance checks.

The following checks have been upgraded from `warning` to `error`:

 - HasDescriptionAttribute

The following checks have been downgraded from `error` to `warning`:

 - ModifyReturnsDifferentType