### PR TITLE
Adding InteropabilityTestSettings object

### DIFF
--- a/InteroperabilityTest_Engine/Compute/ComputePushPullCompareDifferences.cs
+++ b/InteroperabilityTest_Engine/Compute/ComputePushPullCompareDifferences.cs
@@ -58,7 +58,7 @@ namespace BH.Engine.Test.Interoperability
 
                 if (refRes == null)
                 {
-                    fullResult.Information.Add(refRes.NoReferenceFound());
+                    fullResult.Information.Add(result.NoReferenceFound());
                 }
                 else
                 {

--- a/InteroperabilityTest_Engine/InteroperabilityTest_Engine.csproj
+++ b/InteroperabilityTest_Engine/InteroperabilityTest_Engine.csproj
@@ -38,6 +38,10 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Adapter_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Adapter_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
       <Private>False</Private>

--- a/InteroperabilityTest_oM/InteroperabilityTest_oM.csproj
+++ b/InteroperabilityTest_oM/InteroperabilityTest_oM.csproj
@@ -1,62 +1,63 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTarget="" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-<PropertyGroup>
-  <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-  <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-  <ProjectGuid>{8AA8B55E-0C55-4356-BF8B-98B98F6C346C}</ProjectGuid>
-  <OutputType>Library</OutputType>
-  <AppDesignerFolder>Properties</AppDesignerFolder>
-  <RootNamespace>BH.oM.Test.Interoperability</RootNamespace>
-  <AssemblyName>InteroperabilityTest_oM</AssemblyName>
-  <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-  <FileAlignment>512</FileAlignment>
-</PropertyGroup>
-<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  <DebugSymbols>true</DebugSymbols>
-  <DebugType>full</DebugType>
-  <Optimize>false</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>DEBUG;TRACE</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-  <WarningLevel>4</WarningLevel>
-</PropertyGroup>
-<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  <DebugType>pdbonly</DebugType>
-  <Optimize>true</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-  <WarningLevel>4</WarningLevel>
-</PropertyGroup>
-<ItemGroup>
-  <Reference Include="BHoM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="System" />
-  <Reference Include="System.Core" />
-  <Reference Include="System.Xml.Linq" />
-  <Reference Include="System.Data.DataSetExtensions" />
-  <Reference Include="Microsoft.CSharp" />
-  <Reference Include="System.Data" />
-  <Reference Include="System.Net.Http" />
-  <Reference Include="System.Xml" />
-  <Reference Include="Test_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Test_oM.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-</ItemGroup>
-<ItemGroup>
-  <Compile Include="Enums\ComparerType.cs" />
-  <Compile Include="Properties\AssemblyInfo.cs" />
-  <Compile Include="PushPullCompareConfig.cs" />
-  <Compile Include="Results\PushPullObjectComparison.cs" />
-</ItemGroup>
-<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
-<PropertyGroup>
-  <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
-</PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8AA8B55E-0C55-4356-BF8B-98B98F6C346C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.oM.Test.Interoperability</RootNamespace>
+    <AssemblyName>InteroperabilityTest_oM</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BHoM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Test_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Test_oM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Enums\ComparerType.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PushPullCompareConfig.cs" />
+    <Compile Include="Results\PushPullObjectComparison.cs" />
+    <Compile Include="Settings\InteropabilityTestSettings.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/InteroperabilityTest_oM/Settings/InteropabilityTestSettings.cs
+++ b/InteroperabilityTest_oM/Settings/InteropabilityTestSettings.cs
@@ -1,4 +1,26 @@
-﻿using System;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/InteroperabilityTest_oM/Settings/InteropabilityTestSettings.cs
+++ b/InteroperabilityTest_oM/Settings/InteropabilityTestSettings.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+using BH.oM.Base;
+
+namespace BH.oM.Test.Interoperability.Settings
+{
+    [Description("All settings needed to run a PushPullCompare for a specific adapter.")]
+    public class InteropabilityTestSettings : BHoMObject
+    {
+        [Description("The type of adapter to test.")]
+        public virtual Type AdapterType { get; set; }
+
+        [Description("The arguments required by the constructor of the adapter with the largest set of arguments.")]
+        public virtual List<object> AdapterConstructorArguments { get; set; } = new List<object>();
+
+        [Description("The types of objects to be tested")]
+        public virtual List<Type> TestTypes { get; set; } = new List<Type>();
+
+        [Description("Config to be used for the PushPullCompare method.")]
+        public virtual PushPullCompareConfig PushPullConfig { get; set; }
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Depends on

https://github.com/BHoM/BHoM_Adapter/pull/301

Need to merge before the above PR before this. Change of strategy of where to add the new method made this toolkit depending on the above branch.

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #352

 <!-- Add short description of what has been fixed -->

Adding setting object to store toolkit specific settings for running PushPullCompare

Adding method for running a PushPullCompare straight from a settings object

Changed the PushPullCOmpare method to be working with the IBHoMAdapter interface rather than the IBHoMAdapter.


 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/Euu1yMnGrLxDoi2BGc4nHogB_a7P9pYg0ldMq--ZUOjauw?e=7qkMus

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->