### PR TITLE
PushPullCompare from file setting to exit the adapter

### DIFF
--- a/InteroperabilityTest_Engine/Compute/PushPullCompare.cs
+++ b/InteroperabilityTest_Engine/Compute/PushPullCompare.cs
@@ -53,9 +53,9 @@ namespace BH.Engine.Test.Interoperability
         [Description("Runs a PushPullCompare test on an adapter based on provided InteropabilityTestSettings.\n" +
                      "Creates the adapter based on the setting objects and runs through a PushPullCompare run for each provided type. Ends by calling the Exit command of the adapter, closing down any running software process." +
                      "Requires the setting obejct to be fully defined and returns null if failing to initialise the test.\n" + 
-                     "For successfull runs returns a testresult per testset run.")]
+                     "For successfull runs returns a TestResult per test set run.")]
         [Input("settings", "InteropabilityTestSettings object containing information on which adapter to test, how to construct the adapter, types to test and settings for the testing.")]
-        [Output("testResult", "Diffing results outlining any differences found between the pushed and pulled objects, one TestResult per testset.")]
+        [Output("testResult", "Diffing results outlining any differences found between the pushed and pulled objects, one TestResult per test set.")]
         public static List<TestResult> PushPullCompare(InteropabilityTestSettings settings)
         {
             //Check settings for null

--- a/InteroperabilityTest_Engine/Compute/PushPullCompare.cs
+++ b/InteroperabilityTest_Engine/Compute/PushPullCompare.cs
@@ -90,6 +90,9 @@ namespace BH.Engine.Test.Interoperability
                 results.AddRange(PushPullCompare(adapter, type, settings.PushPullConfig, true));
             }
 
+            //Ask the adapter to fully close down any open instance of the software
+            adapter.Execute(new Exit { SaveBeforeClose = false });
+
             return results;
         }
 

--- a/InteroperabilityTest_Engine/Compute/PushPullCompare.cs
+++ b/InteroperabilityTest_Engine/Compute/PushPullCompare.cs
@@ -50,6 +50,12 @@ namespace BH.Engine.Test.Interoperability
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Runs a PushPullCompare test on an adapter based on provided InteropabilityTestSettings.\n" +
+                     "Creates the adapter based on the setting objects and runs through a PushPullCompare run for each provided type. Ends by calling the Exit command of the adapter, closing down any running software process." +
+                     "Requires the setting obejct to be fully defined and returns null if failing to initialise the test.\n" + 
+                     "For successfull runs returns a testresult per testset run.")]
+        [Input("settings", "InteropabilityTestSettings object containing information on which adapter to test, how to construct the adapter, types to test and settings for the testing.")]
+        [Output("testResult", "Diffing results outlining any differences found between the pushed and pulled objects, one TestResult per testset.")]
         public static List<TestResult> PushPullCompare(InteropabilityTestSettings settings)
         {
             //Check settings for null


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM_Adapter/pull/303

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #354 

 <!-- Add short description of what has been fixed -->

Adding call to the Exit command to the adapter as a final clean-up step after the PushPullCompare has been run.

 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->