### PR TITLE
UnitTest_Engine: Fix casting of objects to correct type for recursive lists

### DIFF
--- a/Test_Engine/Query/IsEqual.cs
+++ b/Test_Engine/Query/IsEqual.cs
@@ -71,6 +71,8 @@ namespace BH.Engine.Test
             comparer.Config.MembersToIgnore = config.PropertyExceptions;
             comparer.Config.DoublePrecision = config.NumericTolerance;
             comparer.Config.TypesToIgnore = config.TypeExceptions;
+            comparer.Config.CompareStaticFields = false;
+            comparer.Config.CompareStaticProperties = false;
 
             Output<bool, List<string>, List<string>, List<string>> output = new Output<bool, List<string>, List<string>, List<string>>
             {

--- a/Test_Engine/Query/IsEqual.cs
+++ b/Test_Engine/Query/IsEqual.cs
@@ -55,12 +55,12 @@ namespace BH.Engine.Test
 
         /***************************************************/
 
-        [Description("Checks two objects for equality property by property and returns the differences")]
-        [Input("config", "Config to be used for the comparison. Can set numeric tolerance, wheter to check the guid, if custom data should be ignored and if any additional properties should be ignored")]
-        [MultiOutput(0, "IsEqual", "Returns true if the two items are deemed to be equal")]
-        [MultiOutput(1, "DiffProperty", "List of the names of the properties found to be different")]
-        [MultiOutput(2, "Obj1DiffValue", "List of the values deemed different for object 1")]
-        [MultiOutput(3, "Obj2DiffValue", "List of the values deemed different for object 2")]
+        [Description("Checks two objects for equality property by property and returns the differences. Static properties of the two objects are ignored in the comparison.")]
+        [Input("config", "Config to be used for the comparison. Can set numeric tolerance, wheter to check the guid, if custom data should be ignored and if any additional properties should be ignored.")]
+        [MultiOutput(0, "IsEqual", "Returns true if the two items are deemed to be equal.")]
+        [MultiOutput(1, "DiffProperty", "List of the names of the properties found to be different.")]
+        [MultiOutput(2, "Obj1DiffValue", "List of the values deemed different for object 1.")]
+        [MultiOutput(3, "Obj2DiffValue", "List of the values deemed different for object 2.")]
         public static Output<bool, List<string>, List<string>, List<string>> IsEqual(this object obj1, object obj2, BH.oM.Base.ComparisonConfig config = null)
         {
             //Use default config if null

--- a/UnitTest_Engine/Compute/Run.cs
+++ b/UnitTest_Engine/Compute/Run.cs
@@ -90,6 +90,10 @@ namespace BH.Engine.UnitTest
 
             List<object> result = new List<object>();
             List<string> errors = new List<string>();
+
+            if (method.IsGenericMethod && method is MethodInfo)
+                method = Engine.Reflection.Compute.MakeGenericFromInputs(method as MethodInfo, data.Inputs.Select(x => FixType(x)?.GetType()).ToList());
+
             try
             {
                 ParameterInfo[] parameters = method.GetParameters();
@@ -165,6 +169,30 @@ namespace BH.Engine.UnitTest
             {
                 return item;
             }
+        }
+
+        /***************************************************/
+
+        private static object FixType(object argument)
+        {
+            if (argument is List<object>)
+            {
+                List<object> list = argument as List<object>;
+                List<Type> types = list.Select(x => x.GetType()).Distinct().ToList();
+                if (types.Count == 1)
+                    return CastList(list, list.First() as dynamic);
+                else
+                    return argument;
+            }
+            else
+                return argument;
+        }
+
+        /***************************************************/
+
+        private static List<T> CastList<T>(List<object> list, T first)
+        {
+            return list.Cast<T>().ToList();
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #359
 Closes #360 
 Closes #361 

 <!-- Add short description of what has been fixed -->

Ensuring that casting of lists to correct types is recursive.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FTest%5FToolkit%2F%23360%2DFixCheckingOfMultiLayerList

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->