### PR TITLE
Update Project checking to include assembly file information

### DIFF
--- a/CodeComplianceTest_Engine/CodeComplianceTest_Engine.csproj
+++ b/CodeComplianceTest_Engine/CodeComplianceTest_Engine.csproj
@@ -126,8 +126,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\CheckAssemblyInfo.cs" />
     <Compile Include="Compute\CheckProjectStructure.cs" />
-    <Compile Include="Compute\CheckReferences.cs" />
+    <Compile Include="Compute\CheckProjectFile.cs" />
     <Compile Include="Compute\Check.cs" />
     <Compile Include="Convert\ToSyntaxTree.cs" />
     <Compile Include="Convert\ToSpan.cs" />
@@ -174,6 +175,7 @@
     <Compile Include="Query\AllChecks.cs" />
     <Compile Include="Query\Checks\PreviousInputNamesAttributeHasMatchingParameter.cs" />
     <Compile Include="Query\Checks\PreviousInputNamesAttributeIsUnique.cs" />
+    <Compile Include="Query\CurrentVersion.cs" />
     <Compile Include="Query\DescriptionAttribute.cs" />
     <Compile Include="Query\DirectlyInherits.cs" />
     <Compile Include="Query\DynamicChecks\AdapterCreateMethodIsValid.cs" />

--- a/CodeComplianceTest_Engine/Compute/CheckAssemblyInfo.cs
+++ b/CodeComplianceTest_Engine/Compute/CheckAssemblyInfo.cs
@@ -1,0 +1,130 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Test.CodeCompliance;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+using System.IO;
+
+using System.Xml.Linq;
+
+using BH.oM.Test.CodeCompliance.Attributes;
+
+using BH.oM.Test;
+using BH.oM.Test.Results;
+
+namespace BH.Engine.Test.CodeCompliance
+{
+    public static partial class Compute
+    {
+        public static TestResult CheckAssemblyInfo(this string assemblyInfoPath, string assemblyDescriptionOrg)
+        {
+            if (!assemblyInfoPath.EndsWith("AssemblyInfo.cs"))
+                return Create.TestResult(TestStatus.Pass);
+
+            if (!File.Exists(assemblyInfoPath))
+                return Create.TestResult(TestStatus.Pass);
+
+            TestResult finalResult = Create.TestResult(TestStatus.Pass);
+            string documentationLink = "AssemblyInfo-compliance";
+
+            List<string> fileLines = ReadFileContents(assemblyInfoPath);
+
+            finalResult = CheckAssemblyVersion(fileLines, finalResult, assemblyInfoPath, documentationLink);
+            finalResult = CheckAssemblyFileVersion(fileLines, finalResult, assemblyInfoPath, documentationLink);
+            finalResult = CheckAssemblyDescription(fileLines, finalResult, assemblyInfoPath, documentationLink, assemblyDescriptionOrg);
+
+            return finalResult;
+        }
+
+        private static TestResult CheckAssemblyVersion(this List<string> fileLines, TestResult finalResult, string assemblyInfoPath, string documentationLink)
+        {
+            string currentAssemblyVersion = Query.FullCurrentAssemblyVersion();
+
+            string searchLine = $"[assembly: AssemblyVersion(\"";
+
+            string foundLine = fileLines.Where(x => x.StartsWith(searchLine)).FirstOrDefault();
+
+            if (string.IsNullOrEmpty(foundLine))
+                return finalResult.Merge(Create.TestResult(TestStatus.Error, new List<Error> { Create.Error($"Assembly Version should be set to {currentAssemblyVersion}", Create.Location(assemblyInfoPath, Create.LineSpan(1, 1)), documentationLink) }));
+            else
+            {
+                string allowedLine = $"{searchLine}{Query.FullCurrentAssemblyVersion()}\")]";
+                int line = fileLines.IndexOf(foundLine) + 1;
+                if (!foundLine.Contains(allowedLine))
+                    return finalResult.Merge(Create.TestResult(TestStatus.Error, new List<Error> { Create.Error($"Assembly Version should be set to {currentAssemblyVersion}", Create.Location(assemblyInfoPath, Create.LineSpan(line, line)), documentationLink) }));
+            }
+
+            return finalResult;
+        }
+
+        private static TestResult CheckAssemblyFileVersion(this List<string> fileLines, TestResult finalResult, string assemblyInfoPath, string documentationLink)
+        {
+            string currentAssemblyVersion = Query.FullCurrentAssemblyFileVersion();
+
+            string searchLine = $"[assembly: AssemblyFileVersion(\"";
+
+            string foundLine = fileLines.Where(x => x.StartsWith(searchLine)).FirstOrDefault();
+
+            if (string.IsNullOrEmpty(foundLine))
+                return finalResult.Merge(Create.TestResult(TestStatus.Error, new List<Error> { Create.Error($"Assembly File Version should be set to {currentAssemblyVersion}", Create.Location(assemblyInfoPath, Create.LineSpan(1, 1)), documentationLink) }));
+            else
+            {
+                string allowedLine = $"{searchLine}{Query.FullCurrentAssemblyFileVersion()}\")]";
+                int line = fileLines.IndexOf(foundLine) + 1;
+                if (!foundLine.Contains(allowedLine))
+                    return finalResult.Merge(Create.TestResult(TestStatus.Error, new List<Error> { Create.Error($"Assembly File Version should be set to {currentAssemblyVersion}", Create.Location(assemblyInfoPath, Create.LineSpan(line, line)), documentationLink) }));
+            }
+
+            return finalResult;
+        }
+
+        private static TestResult CheckAssemblyDescription(this List<string> fileLines, TestResult finalResult, string assemblyInfoPath, string documentationLink, string descriptionUrl)
+        {
+            string searchLine = $"[assembly: AssemblyDescription(\"";
+
+            string foundLine = fileLines.Where(x => x.StartsWith(searchLine)).FirstOrDefault();
+
+            if (string.IsNullOrEmpty(foundLine))
+                return finalResult.Merge(Create.TestResult(TestStatus.Error, new List<Error> { Create.Error($"Assembly Description should contain the URL to the GitHub organisation which owns the repository", Create.Location(assemblyInfoPath, Create.LineSpan(1, 1)), documentationLink) }));
+            else
+            {
+                string allowedLine = $"{searchLine}{Query.FullCurrentAssemblyFileVersion()}\")]";
+                int line = fileLines.IndexOf(foundLine) + 1;
+                if (!foundLine.Contains(allowedLine))
+                    return finalResult.Merge(Create.TestResult(TestStatus.Error, new List<Error> { Create.Error($"Assembly Description should contain the URL to the GitHub organisation which owns the repository", Create.Location(assemblyInfoPath, Create.LineSpan(line, line)), documentationLink) }));
+            }
+
+            return finalResult;
+        }
+    }
+}
+
+
+

--- a/CodeComplianceTest_Engine/Query/Checks/HasValidPreviousVersionAttribute.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasValidPreviousVersionAttribute.cs
@@ -43,9 +43,9 @@ namespace BH.Engine.Test.CodeCompliance.Checks
 
             List<AttributeSyntax> previousVersionAttributes = node.GetAttributes("PreviousVersion");
 
-            string currentVersion = "5.3"; //Update each milestone - don't forget the one below!
+            string currentVersion = BH.Engine.Test.CodeCompliance.Query.CurrentAssemblyFileVersion();
 
-            foreach(AttributeSyntax a in previousVersionAttributes)
+            foreach (AttributeSyntax a in previousVersionAttributes)
             {
                 string givenVersion = a.ArgumentList.Arguments[0].Expression.GetFirstToken().Value.ToString();
 
@@ -68,7 +68,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
 
             List<AttributeSyntax> previousVersionAttributes = node.GetAttributes("PreviousVersion");
 
-            string currentVersion = "5.3"; //Update each milestone - don't forget the one above!
+            string currentVersion = BH.Engine.Test.CodeCompliance.Query.CurrentAssemblyFileVersion();
 
             foreach (AttributeSyntax a in previousVersionAttributes)
             {

--- a/CodeComplianceTest_Engine/Query/CurrentVersion.cs
+++ b/CodeComplianceTest_Engine/Query/CurrentVersion.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/CodeComplianceTest_Engine/Query/CurrentVersion.cs
+++ b/CodeComplianceTest_Engine/Query/CurrentVersion.cs
@@ -1,4 +1,26 @@
-﻿using System;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/CodeComplianceTest_Engine/Query/CurrentVersion.cs
+++ b/CodeComplianceTest_Engine/Query/CurrentVersion.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.Test.CodeCompliance
+{
+    public static partial class Query
+    {
+        public static string CurrentAssemblyVersion()
+        {
+            return "5.0"; //Update each year - don't forget the one below!
+        }
+
+        public static string FullCurrentAssemblyVersion()
+        {
+            return $"{CurrentAssemblyVersion()}.0.0";
+        }
+
+        public static string CurrentAssemblyFileVersion()
+        {
+            return "5.3"; //Update each milestone - don't forget the one above!
+        }
+
+        public static string FullCurrentAssemblyFileVersion()
+        {
+            return $"{CurrentAssemblyFileVersion()}.0.0";
+        }
+    }
+}

--- a/CodeCompliance_oM/CSProject/ProjectFile.cs
+++ b/CodeCompliance_oM/CSProject/ProjectFile.cs
@@ -34,6 +34,11 @@ namespace BH.oM.Test.CodeCompliance
         public virtual List<string> OutputPaths { get; set; } = new List<string>();
 
         public virtual List<string> TargetNETVersions { get; set; } = new List<string>();
+        public virtual string AssemblyFileVersion { get; set; } = ""; //5.1.0.0
+        public virtual string AssemblyVersion { get; set; } = ""; //5.0.0.0
+        public virtual string AssemblyDescription { get; set; } = "";
+
+        public virtual string PostBuildEvent { get; set; } = "";
 
         public bool IsOldStyle { get; set; } = false;
     }


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #389 


 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
This introduces the ability to  check `AssemblyInfo.cs` files for their compliance to our guidelines on `AssemblyVersion`, `AssemblyFileVersion`, and `AssemblyDescription`.

Also updates the `CSProject` check to include the above as well for the new style project files which replace `AssemblyInfo.cs`.