### PR TITLE
Handle double spacing

### DIFF
--- a/CodeComplianceTest_Engine/Compute/CheckProjectFile.cs
+++ b/CodeComplianceTest_Engine/Compute/CheckProjectFile.cs
@@ -254,8 +254,12 @@ namespace BH.Engine.Test.CodeCompliance
 
             if(!csProject.PostBuildEvent.Any(x => x.Contains(postBuildShouldContain)))
             {
-                int lineNumber = fileLines.IndexOf(fileLines.Where(x => x.Contains(searchLine)).FirstOrDefault()) + 1; //+1 because index is 0 based but line numbers start at 1 for the spans
-                return finalResult.Merge(Create.TestResult(TestStatus.Error, new List<Error> { Create.Error($"Post Build event should be correctly set to copy the compiled DLL to the BHoM Assemblies folder", Create.Location(csProjFilePath, Create.LineSpan(lineNumber, lineNumber)), documentationLink) }));
+                postBuildShouldContain = "&quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\\ProgramData\\BHoM\\Assemblies&quot; /Y"; //Check again with a double spacing
+                if (!csProject.PostBuildEvent.Any(x => x.Contains(postBuildShouldContain)))
+                {
+                    int lineNumber = fileLines.IndexOf(fileLines.Where(x => x.Contains(searchLine)).FirstOrDefault()) + 1; //+1 because index is 0 based but line numbers start at 1 for the spans
+                    return finalResult.Merge(Create.TestResult(TestStatus.Error, new List<Error> { Create.Error($"Post Build event should be correctly set to copy the compiled DLL to the BHoM Assemblies folder", Create.Location(csProjFilePath, Create.LineSpan(lineNumber, lineNumber)), documentationLink) }));
+                }
             }
 
             return finalResult;


### PR DESCRIPTION
Fixes #389 

Allows for double spacing in new-style CSProject post build commands.