### PR TITLE
Fix merge UnitTest

### DIFF
--- a/UnitTest_Engine/Compute/MergeUnitTests.cs
+++ b/UnitTest_Engine/Compute/MergeUnitTests.cs
@@ -42,6 +42,17 @@ namespace BH.Engine.UnitTest
         [Output("mergedTests", "The list of merged UnitTests.")]
         public static List<oM.Test.UnitTests.UnitTest> MergeUnitTests(List<oM.Test.UnitTests.UnitTest> testsToMerge)
         {
+            int initialCount = testsToMerge.Count;
+            testsToMerge = testsToMerge.Where(x => x != null).ToList(); //Filter out nulls
+            if (initialCount != testsToMerge.Count)
+                Base.Compute.RecordWarning("Null UnitTests provided have been culled out and not merged.");
+
+            if (testsToMerge.Count == 0)
+            {
+                Base.Compute.RecordWarning("No non-null tests provided to merge. Emtpy list returned.");
+                return new List<oM.Test.UnitTests.UnitTest>();
+            }
+
             List<oM.Test.UnitTests.UnitTest> mergedTests = new List<oM.Test.UnitTests.UnitTest>();
 
             foreach (var group in testsToMerge.GroupBy(x => x.Method.ToJson()))

--- a/UnitTest_Engine/Compute/MergeUnitTests.cs
+++ b/UnitTest_Engine/Compute/MergeUnitTests.cs
@@ -27,6 +27,7 @@ using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Base;
 using BH.oM.Test.UnitTests;
+using BH.Engine.Serialiser;
 
 namespace BH.Engine.UnitTest
 {
@@ -43,9 +44,9 @@ namespace BH.Engine.UnitTest
         {
             List<oM.Test.UnitTests.UnitTest> mergedTests = new List<oM.Test.UnitTests.UnitTest>();
 
-            foreach (var group in testsToMerge.GroupBy(x => x.Method))
+            foreach (var group in testsToMerge.GroupBy(x => x.Method.ToJson()))
             {
-                mergedTests.Add(new oM.Test.UnitTests.UnitTest { Method = group.Key, Data = group.SelectMany(x => x.Data).ToList() });
+                mergedTests.Add(new oM.Test.UnitTests.UnitTest { Method = group.First().Method, Data = group.SelectMany(x => x.Data).ToList() });
             }
 
             return mergedTests;

--- a/UnitTest_Engine/Compute/StoreUnitTest.cs
+++ b/UnitTest_Engine/Compute/StoreUnitTest.cs
@@ -50,7 +50,7 @@ namespace BH.Engine.UnitTest
         [Input("replacePreExisting", "If true, replaces any pre-existing dataset in the folder.")]
         [Input("activate", "Toggle to push dataset to file.")]
         [Output("success", "Returns true if sucessfully able to write the dataset to file.")]
-        public static bool StoreUnitTests(List<BH.oM.Test.UnitTests.UnitTest> unitTests, string repoFolder, string sourceLink, string author = "", Confidence confidence = Confidence.Undefined, bool checkAssemblyFolder = true, bool replacePreExisting = false, bool activate = false)
+        public static bool StoreUnitTests(List<BH.oM.Test.UnitTests.UnitTest> unitTests, string repoFolder, string sourceLink = "", string author = "", Confidence confidence = Confidence.Undefined, bool checkAssemblyFolder = true, bool replacePreExisting = false, bool activate = false)
         {
             bool success = true;
 

--- a/UnitTest_Engine/Compute/StoreUnitTest.cs
+++ b/UnitTest_Engine/Compute/StoreUnitTest.cs
@@ -188,7 +188,7 @@ namespace BH.Engine.UnitTest
                 return false;
             }
 
-            if (string.IsNullOrEmpty(dataset.SourceInformation.SourceLink) || !dataset.SourceInformation.SourceLink.StartsWith("https://"))
+            if (!string.IsNullOrEmpty(dataset.SourceInformation.SourceLink) && !dataset.SourceInformation.SourceLink.StartsWith("https://"))
             {
                 Engine.Base.Compute.RecordError("Dataset source does not contain a valid source link. Should be a link starting with 'https://'.");
                 return false;

--- a/UnitTest_Engine/Create/Dataset/UnitTestDataSet.cs
+++ b/UnitTest_Engine/Create/Dataset/UnitTestDataSet.cs
@@ -63,6 +63,13 @@ namespace BH.Engine.UnitTest
 
             //Merge unittests of the same method
             List<BH.oM.Test.UnitTests.UnitTest> mergedTests = Compute.MergeUnitTests(unitTests);
+
+            if (mergedTests.Count == 0)
+            {
+                Engine.Base.Compute.RecordError($"No valid {nameof(BH.oM.Test.UnitTests.UnitTest)}s provided. No Dataset created.");
+                return new List<Dataset>();
+            }
+
             List<Dataset> datasets = new List<Dataset>();
             foreach (var group in mergedTests.GroupBy(x => new { Name = x.Method.NonInterfaceName(), T = x.Method.DeclaringType }))
             {


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #401 
Closes #333 
Additional fix for #399 

 <!-- Add short description of what has been fixed -->

- Change grouping of MergeUnitTest to rely on json representation rather than straight reference that was causing issues with modified UTs due to deepcloning.
- Filter out null UTs before merge
- Additional check for valid source link changed for #399 

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EjJYNYuLl2lLpMW8KOMnb7QBgfept7lQUvJDYiAaXMAKOw?e=PgE8aL

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->