### PR TITLE
Update TestRunner to accept methods with single boolean inputs

### DIFF
--- a/TestRunner/Program.cs
+++ b/TestRunner/Program.cs
@@ -61,7 +61,19 @@ namespace TestRunner
                 {
                     try
                     {
-                        TestResult result = method.Invoke(null, new object[] { }) as TestResult;
+                        object[] parameters = new object[] { };
+                        if (method.GetParameters().Length == 1)
+                        {
+                            if (args.Length == 2)
+                            {
+                                parameters = new object[] { System.Convert.ToBoolean(args[1]) };
+                            }
+                            else if (method.GetParameters()[0].HasDefaultValue)
+                            {
+                                parameters = new object[] { method.GetParameters()[0].DefaultValue };
+                            }
+                        }
+                        TestResult result = method.Invoke(null, parameters) as TestResult;
                         Console.WriteLine();
                         Console.Write(result.FullMessage());
                     }
@@ -89,7 +101,7 @@ namespace TestRunner
                         Assembly asm = Assembly.LoadFrom(file);
                         foreach (Type type in asm.GetTypes().Where(x => x.Name == "Verify" && x.Namespace.StartsWith("BH.Test")))
                         {
-                            foreach (MethodInfo method in type.GetMethods(BindingFlags.Static | BindingFlags.Public).Where(x => x.ReturnType == typeof(TestResult) && x.GetParameters().Count() == 0))
+                            foreach (MethodInfo method in type.GetMethods(BindingFlags.Static | BindingFlags.Public).Where(x => x.ReturnType == typeof(TestResult) && (x.GetParameters().Count() == 0 || (x.GetParameters().Count() == 1 && x.GetParameters()[0].ParameterType == typeof(bool)))))
                                 RegisterTestMethod(method);
                         }
                     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #406

 <!-- Add short description of what has been fixed -->

Making TestRunner able to run versioning verification after changes in https://github.com/BHoM/Versioning_Toolkit/pull/201

Made the filtering quite explicit to only allow for methods with single boolean input on top of the previously accepted 0 argument methods. Not sure if we want to expand the scope even further or not.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

To be tested by use of the TestRunner

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->