### PR TITLE
Change IsExtensionMethod to ignore system types

### DIFF
--- a/CodeComplianceTest_Engine/Query/Checks/IsExtensionMethod.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsExtensionMethod.cs
@@ -50,11 +50,33 @@ namespace BH.Engine.Test.CodeCompliance.Checks
                 return null;
 
             var parameters = node.ParameterList.Parameters;
-            if (parameters.Count > 0)
+            if (parameters.Count > 0 && !m_systemTypes.Contains(parameters[0].Type.ToString()))
                 return parameters[0].Modifiers.Any(mod => mod.Kind() == SyntaxKind.ThisKeyword) ? null : parameters[0].Span.ToSpan();
 
             return null;
         }
+
+        private static List<string> m_systemTypes = new List<string>()
+        {
+            "bool",
+            "byte",
+            "sbyte",
+            "char",
+            "decimal",
+            "double",
+            "float",
+            "int",
+            "uint",
+            "nint",
+            "nuint",
+            "long",
+            "ulong",
+            "short",
+            "ushort",
+            "object",
+            "string",
+            "dynamic",
+        };
 
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #385 


 ### Test files
`BHoM_Engine/Query/IsAdapterAssembly.cs` contains a `this string` method (line 48) which can be used to test with.

Try with a few types though if you wish to confirm. However, system types should no longer be flagged as needing the `this` keyword.


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments

Took the exclusion list from [here](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types).