### PR TITLE
Upgrade System.Runtime.CompilerServices.Unsafe.dll to 5.0.0.0

### DIFF
--- a/CodeComplianceTest_Engine/CodeComplianceTest_Engine.csproj
+++ b/CodeComplianceTest_Engine/CodeComplianceTest_Engine.csproj
@@ -100,8 +100,8 @@
     <Reference Include="System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encoding.CodePages, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encoding.CodePages.4.5.1\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
@@ -232,6 +232,7 @@
     <Compile Include="Query\DynamicChecks\ConvertMethodIsValid.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/CodeComplianceTest_Engine/app.config
+++ b/CodeComplianceTest_Engine/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/CodeComplianceTest_Engine/packages.config
+++ b/CodeComplianceTest_Engine/packages.config
@@ -9,7 +9,7 @@
   <package id="System.Memory" version="4.5.3" targetFramework="net461" />
   <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net472" />
   <package id="System.Text.Encoding.CodePages" version="4.5.1" targetFramework="net461" />
   <package id="System.Threading.Tasks.Dataflow" version="4.9.0" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.3" targetFramework="net461" />

--- a/Test_Toolkit.sln
+++ b/Test_Toolkit.sln
@@ -1,17 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 14 for Windows Desktop
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.33027.108
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InteroperabilityTest_Engine", "InteroperabilityTest_Engine\InteroperabilityTest_Engine.csproj", "{DF4047D7-2883-4763-83C0-B1D3B391D454}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeComplianceTest_Engine", "CodeComplianceTest_Engine\CodeComplianceTest_Engine.csproj", "{5E17BA6F-F159-47DD-865C-F2DAA235AAC7}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeComplianceTest_Test", "CodeComplianceTest_Test\CodeComplianceTest_Test.csproj", "{9991DC89-7BD1-485F-B756-510CEF48E4F0}"
-	ProjectSection(ProjectDependencies) = postProject
-		{5E17BA6F-F159-47DD-865C-F2DAA235AAC7} = {5E17BA6F-F159-47DD-865C-F2DAA235AAC7}
-		{F758FC9C-CEDF-430D-AEFF-2B1E196F677B} = {F758FC9C-CEDF-430D-AEFF-2B1E196F677B}
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test_Engine", "Test_Engine\Test_Engine.csproj", "{5FC85409-DBC5-4B0D-A2AA-1D9542F0763B}"
 EndProject
@@ -43,12 +37,6 @@ Global
 		{5E17BA6F-F159-47DD-865C-F2DAA235AAC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E17BA6F-F159-47DD-865C-F2DAA235AAC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E17BA6F-F159-47DD-865C-F2DAA235AAC7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9991DC89-7BD1-485F-B756-510CEF48E4F0}.ComplianceTestBuild|Any CPU.ActiveCfg = ComplianceTestBuild|Any CPU
-		{9991DC89-7BD1-485F-B756-510CEF48E4F0}.ComplianceTestBuild|Any CPU.Build.0 = ComplianceTestBuild|Any CPU
-		{9991DC89-7BD1-485F-B756-510CEF48E4F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9991DC89-7BD1-485F-B756-510CEF48E4F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9991DC89-7BD1-485F-B756-510CEF48E4F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9991DC89-7BD1-485F-B756-510CEF48E4F0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5FC85409-DBC5-4B0D-A2AA-1D9542F0763B}.ComplianceTestBuild|Any CPU.ActiveCfg = Release|Any CPU
 		{5FC85409-DBC5-4B0D-A2AA-1D9542F0763B}.ComplianceTestBuild|Any CPU.Build.0 = Release|Any CPU
 		{5FC85409-DBC5-4B0D-A2AA-1D9542F0763B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->