### PR TITLE
NUnitTest_Engine: do not attempt to load assemblies from project reference when the context is the ProgramData BHoM folder

### DIFF
--- a/NUnit_Engine/NUnitTest.cs
+++ b/NUnit_Engine/NUnitTest.cs
@@ -39,11 +39,16 @@ namespace BH.oM.Test.NUnit
     {
 
         [OneTimeSetUp]
-        [Description("Loads all assemblies referenced by the derived Test class' project. " +
+        [Description("Loads all assemblies referenced by the derived Test class' project, when in a Test Explorer context. " +
             "This is required to make sure that otherwise lazy-loaded assemblies are loaded upfront, " +
             "in order to avoid runtime errors when using dynamic mechanisms like RunExtensionMethod().")]
         public void LoadReferencedAssemblies()
         {
+            // If the tests are being run from a process that is based in ProgramData (e.g. BHoMBot),
+            // this method does not apply, because we assume that all the available assemblies are pre-loaded by such process. Return.
+            if (AppDomain.CurrentDomain.BaseDirectory.EndsWith(@"ProgramData\BHoM\Assemblies\"))
+                return;
+
             // Get the referenced assemblies of the Test Project.
             var testProjectDir = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory).Parent.Parent.Parent.FullName;
             var files = Directory.GetFiles(testProjectDir, "*.csproj");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #444

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
Test via BHoMBot.

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
The `LoadReferencedAssemblies()` method just returns when invoked via BHoMBot.
