### PR TITLE
Rule out verification solutions and versioning toolkit from irrelevant checks

### DIFF
--- a/CodeComplianceTest_Engine/Compute/CheckProjectFile.cs
+++ b/CodeComplianceTest_Engine/Compute/CheckProjectFile.cs
@@ -124,8 +124,11 @@ namespace BH.Engine.Test.CodeCompliance
 
         private static TestResult CheckOutputPath(this ProjectFile csProject, List<string> fileLines, TestResult finalResult, string csProjFilePath, string documentationLink)
         {
-            List<string> acceptableOutputPaths = new List<string>() { "..\\Build\\" };
+            if (csProjFilePath.Contains("Versioning_Toolkit"))  //Do not require build paths for Versioning_Toolkit
+                return finalResult;
 
+            List<string> acceptableOutputPaths = new List<string>() { "..\\Build\\" };
+            
             foreach(string outputPath in csProject.OutputPaths)
             {
                 if(!string.IsNullOrEmpty(outputPath) && !acceptableOutputPaths.Contains(outputPath))
@@ -240,6 +243,9 @@ namespace BH.Engine.Test.CodeCompliance
 
         private static TestResult CheckPostBuild(this ProjectFile csProject, List<string> fileLines, TestResult finalResult, string csProjFilePath, string documentationLink)
         {
+            if (csProjFilePath.Contains("Versioning_Toolkit"))  //Versioning_Toolkit should _not_ copy to assemblies folder
+                return finalResult;
+
             string postBuildShouldContain = "";
             string searchLine = "";
             if (csProject.IsOldStyle)

--- a/CodeComplianceTest_Engine/Query/Checks/EngineClassMatchesFilePath.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/EngineClassMatchesFilePath.cs
@@ -38,7 +38,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Message("Incorrect Engine class name based on file path", "EngineClassMatchesFilePath")]
         [Path(@"([A-Za-z0-9]+)_Engine\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]
         public static Span EngineClassMatchesFilePath(this ClassDeclarationSyntax node)

--- a/CodeComplianceTest_Engine/Query/Checks/HasConstructor.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasConstructor.cs
@@ -41,7 +41,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Adapter\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]
         [Output("A span that represents where this error resides or null if there is no error")]

--- a/CodeComplianceTest_Engine/Query/Checks/HasOneConstructor.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasOneConstructor.cs
@@ -41,7 +41,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Adapter\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]
         [Output("A span that represents where this error resides or null if there is no error")]

--- a/CodeComplianceTest_Engine/Query/Checks/HasPublicGet.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasPublicGet.cs
@@ -39,7 +39,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Adapter\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [IsPublic()]
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]

--- a/CodeComplianceTest_Engine/Query/Checks/HasValidConstructor.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasValidConstructor.cs
@@ -41,7 +41,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Adapter\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]
         [Output("A span that represents where this error resides or null if there is no error")]

--- a/CodeComplianceTest_Engine/Query/Checks/HasValidPreviousVersionAttribute.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasValidPreviousVersionAttribute.cs
@@ -34,7 +34,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [ErrorLevel(TestStatus.Error)]
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [IsPublic()]
         [ComplianceType("documentation")]
         public static Span HasValidPreviousVersionAttribute(this MethodDeclarationSyntax node)

--- a/CodeComplianceTest_Engine/Query/Checks/HiddenInputsAreLast.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HiddenInputsAreLast.cs
@@ -38,7 +38,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Message("UIExposure for some inputs are set to hidden, but the corresponding input parameter is not last in the parameter list.", "HiddenInputsAreLast")]
         [ErrorLevel(TestStatus.Warning)]
         [Path(@"([a-zA-Z0-9]+)_(Engine|Adapter)\\.*\.cs$")]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("documentation")]
         public static Span HiddenInputsAreLast(this BaseMethodDeclarationSyntax node)
         {

--- a/CodeComplianceTest_Engine/Query/Checks/InputAttributesAreInOrder.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/InputAttributesAreInOrder.cs
@@ -38,7 +38,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Message("Input documentation attributes should be in the same order as the method input parameters.", "InputAttributesAreInOrder")]
         [ErrorLevel(TestStatus.Error)]
         [Path(@"([a-zA-Z0-9]+)_(Engine|Adapter)\\.*\.cs$")]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("documentation")]
         public static Span InputAttributesAreInOrder(this BaseMethodDeclarationSyntax node)
         {

--- a/CodeComplianceTest_Engine/Query/Checks/IsDocumentationURLValid.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsDocumentationURLValid.cs
@@ -42,7 +42,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [ErrorLevel(TestStatus.Error)]
         [Path(@"([a-zA-Z0-9]+)_(oM|Engine|Adapter)\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("documentation")]
         public static Span IsDocumentationURLValid(this AttributeSyntax node)
         {

--- a/CodeComplianceTest_Engine/Query/Checks/IsExtensionMethod.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsExtensionMethod.cs
@@ -42,7 +42,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\Compute\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Create\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [IsPublic()]
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]

--- a/CodeComplianceTest_Engine/Query/Checks/IsPublicClass.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsPublicClass.cs
@@ -38,7 +38,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Message("Invalid Engine class: Engine classes must be public", "IsPublicClass")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [IsPublic(false)]
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]

--- a/CodeComplianceTest_Engine/Query/Checks/IsStaticClass.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsStaticClass.cs
@@ -38,7 +38,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Message("Invalid Engine class: Engine classes must be static", "IsStaticClass")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]
         public static Span IsStaticClass(this ClassDeclarationSyntax node)

--- a/CodeComplianceTest_Engine/Query/Checks/IsUsingCustomData.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsUsingCustomData.cs
@@ -39,7 +39,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [ErrorLevel(TestStatus.Warning)]
         [Path(@"([a-zA-Z0-9]+)_(Engine|Adapter)\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("code")]
         public static Span IsUsingCustomData(this StatementSyntax node)
         {

--- a/CodeComplianceTest_Engine/Query/Checks/IsValidEngineClassName.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsValidEngineClassName.cs
@@ -37,7 +37,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Message("Invalid Engine class name", "IsValidEngineClassName")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]
         public static Span IsValidEngineClassName(this ClassDeclarationSyntax node)

--- a/CodeComplianceTest_Engine/Query/Checks/IsValidIImmutableObject.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsValidIImmutableObject.cs
@@ -43,7 +43,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Adapter\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("code")]
         public static Span IsValidIImmutableObject(this ClassDeclarationSyntax node)
         {

--- a/CodeComplianceTest_Engine/Query/Checks/PreviousInputNamesAttributeHasMatchingParameter.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/PreviousInputNamesAttributeHasMatchingParameter.cs
@@ -38,7 +38,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Message("Previous Input Name attribute does not match any of the given parameters.", "PreviousInputNamesAttributeHasMatchingParameter")]
         [ErrorLevel(TestStatus.Error)]
         [Path(@"([a-zA-Z0-9]+)_(Engine|Adapter)\\.*\.cs$")]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("documentation")]
         public static Span PreviousInputNamesAttributeHasMatchingParameter(this AttributeSyntax node)
         {

--- a/CodeComplianceTest_Engine/Query/Checks/PreviousInputNamesAttributeIsUnique.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/PreviousInputNamesAttributeIsUnique.cs
@@ -38,7 +38,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Message("Previous Input Name attribute is not unique.", "PreviousInputNamesAttributeIsUnique")]
         [ErrorLevel(TestStatus.Error)]
         [Path(@"([a-zA-Z0-9]+)_(Engine|Adapter)\\.*\.cs$")]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("documentation")]
         public static Span PreviousInputNamesAttributeIsUnique(this AttributeSyntax node)
         {

--- a/CodeComplianceTest_Engine/Query/Checks/UIExposureHasDefaultValue.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/UIExposureHasDefaultValue.cs
@@ -38,7 +38,8 @@ namespace BH.Engine.Test.CodeCompliance.Checks
         [Message("UIExposure for input is set to hidden, but the corresponding input parameter does not contain a default value.", "UIExposureHasDefaultValue")]
         [ErrorLevel(TestStatus.Error)]
         [Path(@"([a-zA-Z0-9]+)_(Engine|Adapter)\\.*\.cs$")]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [ComplianceType("documentation")]
         public static Span UIExposureHasDefaultValue(this AttributeSyntax node)
         {


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #482 
Closes #483 

 <!-- Add short description of what has been fixed -->

- Skip checks for build location and postbuild copy for Versioning_Toolkit
- Do not apply the CodeCompliance checks applicable for the _Enigne and _oM project to _Test solutions, such as null-handling and serialisation. Opted to keep a couple of checks in, such as checking for input/output attributes as those where only warnings, and not errors, and actually would be good to have in place.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Test_Toolkit/%23484-RuleOutVerificationSolutionsAndVersioningToolkitFromIrrelevantChecks?csf=1&web=1&e=4dfX67

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->