### PR TITLE
Fix bug for Modify methods on an object that contains 'List' in its type

### DIFF
--- a/CodeComplianceTest_Engine/Query/Checks/IsExtensionMethod.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsExtensionMethod.cs
@@ -55,7 +55,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
             var parameters = node.ParameterList.Parameters;
             if (parameters.Count > 0 && !m_systemTypes.Contains(parameters[0].Type.ToString().ToLower()))
             {
-                if (Regex.Match(parameters[0].Type.ToString(), $"(List|IEnumerable|Dictionary)").Success)
+                if (Regex.Match(parameters[0].Type.ToString(), $"(List|IEnumerable|Dictionary)<").Success)
                 {
                     var typeOptions = parameters[0].Type.ToString().Split('<')[1].Split('>')[0].Split(',');
                     foreach(var t in typeOptions)


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #488 

Adds a check for '<' in the regex to make sure the split is not going to throw an exception.
See issue for full description.


 ### Test files
[CodeComplianceTest.zip](https://github.com/user-attachments/files/17921720/CodeComplianceTest.zip)
Make sure to have the DataViz_Toolkit cloned on its current PR (branch `DataViz_Toolkit-#61-TemplateViews`)

 ### Additional comments
I did the minimum amount of change to avoid disruption but I was wondering if the fact that the regex doesn't limit to the start of the string couldn't create problem. So far, it has worked on all our code so maybe a question to investigate later ?