### PR TITLE
Reduce status from error to warning for attributes in order check

### DIFF
--- a/CodeComplianceTest_Engine/Query/Checks/InputAttributesAreInOrder.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/InputAttributesAreInOrder.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     public static partial class Query
     {
         [Message("Input documentation attributes should be in the same order as the method input parameters.", "InputAttributesAreInOrder")]
-        [ErrorLevel(TestStatus.Error)]
+        [ErrorLevel(TestStatus.Warning)]
         [Path(@"([a-zA-Z0-9]+)_(Engine|Adapter)\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
         [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #497

 <!-- Add short description of what has been fixed -->

Fixes issue where inputs in order where treated as an error, unnecessarily blocking PRs from merge. Check still useful, but should be a warning.

 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->