### PR TITLE
Correct the path arguments to correctly filter as intended

### DIFF
--- a/CodeComplianceTest_Engine/Query/Checks/HasDescriptionAttribute.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/HasDescriptionAttribute.cs
@@ -39,8 +39,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     {
         [Message("Engine Method must contain a Description attribute", "HasDescriptionAttribute")]
         [ErrorLevel(TestStatus.Error)]
-        [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$")]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$")]
+        [Path(@"([a-zA-Z0-9]+)_(Engine|Tests)\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
         [IsPublic()]
         [ComplianceType("documentation")]

--- a/CodeComplianceTest_Engine/Query/Checks/IsPublicProperty.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsPublicProperty.cs
@@ -35,11 +35,10 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     public static partial class Query
     {
         [Message("Invalid oM property: Object properties must be public", "IsPublicProperty")]
-        [Path(@"([a-zA-Z0-9]+)_?oM\\.*\.cs$")]
+        [Path(@"([a-zA-Z0-9]+)(_?oM|_Tests)\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Adapter\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$")]
         [IsPublic(false)]
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]

--- a/CodeComplianceTest_Engine/Query/Checks/IsVirtualProperty.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/IsVirtualProperty.cs
@@ -35,11 +35,10 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     public static partial class Query
     {
         [Message("Invalid oM property: Object properties must be virtual", "IsVirtualProperty")]
-        [Path(@"([a-zA-Z0-9]+)_?oM\\.*\.cs$")]
+        [Path(@"([a-zA-Z0-9]+)(_?oM|_Tests)\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Adapter\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$")]
         [IsPublic()]
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]

--- a/CodeComplianceTest_Engine/Query/Checks/MethodNameContainsFileName.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/MethodNameContainsFileName.cs
@@ -35,9 +35,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     public static partial class Query
     {
         [Message("Method name must start with or end with the name of the file", "MethodNameContainsFileName")]
-        [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$")]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$")]
-        [Path(@"([a-zA-Z0-9]+)_Engine\\Create\\.*\.cs$")]
+        [Path(@"([a-zA-Z0-9]+)_(Engine|Tests)\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Convert\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
         [IsPublic()]

--- a/CodeComplianceTest_Engine/Query/Checks/ObjectNameMatchesFileName.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/ObjectNameMatchesFileName.cs
@@ -38,8 +38,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
 
         [Message("Class (object) name must match file name", "ObjectNameMatchesFileName")]
         [ErrorLevel(TestStatus.Error)]
-        [Path(@"([a-zA-Z0-9]+)_?oM\\.*\.cs$")]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$")]
+        [Path(@"([a-zA-Z0-9]+)(_?oM|_Tests)\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Adapter\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]

--- a/CodeComplianceTest_Engine/Query/Checks/PropertyAccessorsHaveNoBody.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/PropertyAccessorsHaveNoBody.cs
@@ -35,8 +35,7 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     public static partial class Query
     {
         [Message("Invalid oM property: Object property accessors must not have a body", "PropertyAccessorsHaveNoBody")]
-        [Path(@"([a-zA-Z0-9]+)_?oM\\.*\.cs$")]
-        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$")]
+        [Path(@"([a-zA-Z0-9]+)(_?oM|_Tests)\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Adapter\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_UI\\.*\.cs$", false)]


### PR DESCRIPTION

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #509 

 <!-- Add short description of what has been fixed -->

Fixes issue with stacked path arguments introduced in 
https://github.com/BHoM/Test_Toolkit/pull/438 (adding _Tests causing those methods not generally being run)
#456 (Making it so that only create methods are checked for method name contains filename)

 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->

Suggesting we do not merge this until after the coming beta release, as it might mean significantly more compliance failures. For the checks actually run after putting this back on. Just looking at the BHoM_Engine this will give an additional 245 files failing, mostly due to missing Description attributes.