### PR TITLE
Fix issue with CheckAssemblyInfo incorrectly checking itself as AssemblyInfo file

### DIFF
--- a/CodeComplianceTest_Engine/Compute/CheckAssemblyInfo.cs
+++ b/CodeComplianceTest_Engine/Compute/CheckAssemblyInfo.cs
@@ -45,7 +45,10 @@ namespace BH.Engine.Test.CodeCompliance
     {
         public static TestResult CheckAssemblyInfo(this string assemblyInfoPath, string assemblyDescriptionOrg)
         {
-            if (!assemblyInfoPath.EndsWith("AssemblyInfo.cs"))
+            if(string.IsNullOrWhiteSpace(assemblyInfoPath))
+                return Create.TestResult(TestStatus.Pass);
+
+            if (Path.GetFileName(assemblyInfoPath) != "AssemblyInfo.cs")
                 return Create.TestResult(TestStatus.Pass);
 
             if (!File.Exists(assemblyInfoPath))


### PR DESCRIPTION


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #511

 <!-- Add short description of what has been fixed -->

Change filtering from Path endswith to filename equals to avoid having the check check itself.

 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->