### PR TITLE
Make it possible to input arguments to the TestRunner after starting it

### DIFF
--- a/TestRunner/Program.cs
+++ b/TestRunner/Program.cs
@@ -47,12 +47,12 @@ namespace TestRunner
 
             while (args.Length == 0 || !m_TestMethods.ContainsKey(args[0]))
             {
-                if (args.Length == 0)
-                    Console.WriteLine("Please provide a filter for the methods you want to run. This can be either the name of the method or its namespace (after 'BH.Test')");
-                else
+                if (args.Length != 0)
                     Console.WriteLine("Cannot find any test matching " + args[0]);
+                
+                Console.WriteLine("Please provide a filter for the methods you want to run. This can be either the name of the method or its namespace (after 'BH.Test').");
 
-                Console.WriteLine($"Avilable methods to run are: {string.Join(", ", m_TestMethods.Keys)}");
+                Console.WriteLine($"Available methods to run are: {string.Join(", ", m_TestMethods.Keys)}");
 
                 args = Console.ReadLine().Split(' ');
             }


### PR DESCRIPTION

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #513

 <!-- Add short description of what has been fixed -->

Makes it possible to simply double click the TestRUnner.exe and then input the arguments afterwards. Should significantly help when trying to debug tests, as you can attach before triggering the test method. No need for temporary Thread.Sleeps or similar.

 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->

Not to be merged before beta release. Just committing to get of my computer as I used this changed version to help test Versioning.