### PR TITLE
Make Test files no longer required to be matching file name to method name

### DIFF
--- a/CodeComplianceTest_Engine/Query/Checks/MethodNameContainsFileName.cs
+++ b/CodeComplianceTest_Engine/Query/Checks/MethodNameContainsFileName.cs
@@ -35,9 +35,11 @@ namespace BH.Engine.Test.CodeCompliance.Checks
     public static partial class Query
     {
         [Message("Method name must start with or end with the name of the file", "MethodNameContainsFileName")]
-        [Path(@"([a-zA-Z0-9]+)_(Engine|Tests)\\.*\.cs$")]
+        [Path(@"([a-zA-Z0-9]+)_Engine\\.*\.cs$")]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Convert\\.*\.cs$", false)]
         [Path(@"([a-zA-Z0-9]+)_Engine\\Objects\\.*\.cs$", false)]
+        [Path(@"([a-zA-Z0-9]+)_Tests\\.*\.cs$", false)]     //NUnit style projects
+        [Path(@"([a-zA-Z0-9]+)_Test\\.*\.cs$", false)]      //Verification projects
         [IsPublic()]
         [ComplianceType("code")]
         [ErrorLevel(TestStatus.Error)]


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #522

 <!-- Add short description of what has been fixed -->

Fixes issue with Test files being flagged as incompliant when file name does nto match method names.

Test projects are not an Engine and should not live under the same rigid compliance rules as the general Engine does, hence turning it off for them.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Test_Toolkit/%235XX-TurnOffCodeMethodNameCOmplianceForTests?csf=1&web=1&e=762WcR

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->